### PR TITLE
Added supportedBiometricSensors function

### DIFF
--- a/.changeset/rare-maps-rhyme.md
+++ b/.changeset/rare-maps-rhyme.md
@@ -1,0 +1,5 @@
+---
+'capacitor-secure-credentials-plugin': patch
+---
+
+Added supportedBiometricSensors function to help determine what kind of biometric sensor a device might have

--- a/.changeset/rare-maps-rhyme.md
+++ b/.changeset/rare-maps-rhyme.md
@@ -1,5 +1,5 @@
 ---
-'capacitor-secure-credentials-plugin': patch
+'capacitor-secure-credentials-plugin': minor
 ---
 
 Added supportedBiometricSensors function to help determine what kind of biometric sensor a device might have

--- a/android/src/main/java/com/cactuslab/plugins/securecredentials/AuthActivity.java
+++ b/android/src/main/java/com/cactuslab/plugins/securecredentials/AuthActivity.java
@@ -2,25 +2,17 @@ package com.cactuslab.plugins.securecredentials;
 
 import android.content.Context;
 import android.content.Intent;
-import android.os.Build;
 import android.os.Bundle;
-import android.os.Handler;
-
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.biometric.BiometricManager;
 import androidx.biometric.BiometricPrompt;
 import androidx.core.content.ContextCompat;
-
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.util.concurrent.Executor;
-
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.NoSuchPaddingException;
 
 public class AuthActivity extends AppCompatActivity {
 

--- a/android/src/main/java/com/cactuslab/plugins/securecredentials/SecureCredentialsPlugin.java
+++ b/android/src/main/java/com/cactuslab/plugins/securecredentials/SecureCredentialsPlugin.java
@@ -1,9 +1,12 @@
 package com.cactuslab.plugins.securecredentials;
 
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.os.Build;
 import android.util.Log;
 
 import androidx.activity.result.ActivityResult;
+import androidx.biometric.BiometricManager;
 
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
@@ -43,6 +46,9 @@ public class SecureCredentialsPlugin extends Plugin {
     private static final String OPTIONS_KEY = "options";
     private static final String CREDENTIAL_KEY = "credential";
     private static final String SECURITY_LEVEL_KEY = "securityLevel";
+    private static final String BIO_FACE_KEY = "face";
+    private static final String BIO_IRIS_KEY = "iris";
+    private static final String BIO_FINGER_KEY = "fingerprint";
 
     private final SecureCredentialsHelper helper = new SecureCredentialsHelper();
 
@@ -139,6 +145,25 @@ public class SecureCredentialsPlugin extends Plugin {
         SecurityLevel max = helper.maximumSupportedLevel(getContext());
         Log.d(TAG, "maximumSecurityLevel " + max.value);
         call.resolve((new SecureCredentialsResult<>(true, max.value)).toJS());
+    }
+
+    @PluginMethod
+    public void supportedBiometricSensors(PluginCall call) {
+        Log.d(TAG, "supportedBiometricSensors");
+
+        JSObject result = new JSObject();
+        PackageManager pm = getContext().getPackageManager();
+        result.put(BIO_FINGER_KEY, pm.hasSystemFeature(PackageManager.FEATURE_FINGERPRINT));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            result.put(BIO_FACE_KEY, pm.hasSystemFeature(PackageManager.FEATURE_FACE));
+            result.put(BIO_IRIS_KEY, pm.hasSystemFeature(PackageManager.FEATURE_IRIS));
+        } else {
+            result.put(BIO_FACE_KEY, false);
+            result.put(BIO_IRIS_KEY, false);
+        }
+
+        Log.d(TAG, "supportedBiometricSensors " + result.toString());
+        call.resolve((new SecureCredentialsResult<>(true, result)).toJS());
     }
 
     private void startBiometric(final PluginCall call, String service, String username) {

--- a/ios/Gemfile.lock
+++ b/ios/Gemfile.lock
@@ -1,9 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.5)
+    CFPropertyList (3.0.6)
       rexml
-    activesupport (6.1.5)
+    activesupport (6.1.7.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -45,7 +45,7 @@ GEM
       public_suffix (~> 4.0)
       typhoeus (~> 1.0)
     cocoapods-deintegrate (1.0.5)
-    cocoapods-downloader (1.6.1)
+    cocoapods-downloader (1.6.3)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.1)
@@ -54,19 +54,19 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.0)
     escape (0.0.4)
-    ethon (0.15.0)
+    ethon (0.16.0)
       ffi (>= 1.15.0)
     ffi (1.15.5)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     httpclient (2.8.3)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
-    json (2.6.2)
-    minitest (5.15.0)
+    json (2.6.3)
+    minitest (5.17.0)
     molinillo (0.8.0)
     nanaimo (0.3.0)
     nap (1.1.0)
@@ -76,7 +76,7 @@ GEM
     ruby-macho (2.5.1)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     xcodeproj (1.22.0)
       CFPropertyList (>= 2.3.3, < 4.0)
@@ -85,13 +85,14 @@ GEM
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
       rexml (~> 3.2.4)
-    zeitwerk (2.5.4)
+    zeitwerk (2.6.7)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-20
 
 DEPENDENCIES
   cocoapods
 
 BUNDLED WITH
-   2.2.24
+   2.3.20

--- a/ios/Plugin/SecureCredentialsPlugin.m
+++ b/ios/Plugin/SecureCredentialsPlugin.m
@@ -10,4 +10,5 @@ CAP_PLUGIN(SecureCredentialsPlugin, "SecureCredentials",
     CAP_PLUGIN_METHOD(removeCredentials, CAPPluginReturnPromise);
     CAP_PLUGIN_METHOD(setCredential, CAPPluginReturnPromise);
     CAP_PLUGIN_METHOD(maximumSecurityLevel, CAPPluginReturnPromise);
+    CAP_PLUGIN_METHOD(supportedBiometricSensors, CAPPluginReturnPromise);
 )

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -36,6 +36,12 @@ export interface SecureCredentialsError {
     message: string;
 }
 
+export interface BiometricSensors {
+    face: boolean;
+    fingerprint: boolean;
+    iris: boolean;
+}
+
 export interface SecureCredentialsPlugin {
     /**
      * Get a credential matching a service and username if one exists.
@@ -63,4 +69,10 @@ export interface SecureCredentialsPlugin {
      * This may change over the course of an application's lifetime as users may add or remove pins or biometric scanning features.
      */
     maximumSecurityLevel(): Promise<Success<SecurityLevel> | Failure<SecureCredentialsError>>
+    /**
+     * Determine the device capabilities for biometric scanning features. A device may have any combination of sensors and the sensors
+     * available may change depending on whether a user has granted permission to inspect the device sensors or whether they are enrolled
+     * with those sensors. Not all devices advertise what sensors they have. The information gathered is not guaranteed to be 100% accurate. 
+     */
+    supportedBiometricSensors(): Promise<Success<BiometricSensors> | Failure<SecureCredentialsError>>
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -74,5 +74,5 @@ export interface SecureCredentialsPlugin {
      * available may change depending on whether a user has granted permission to inspect the device sensors or whether they are enrolled
      * with those sensors. Not all devices advertise what sensors they have. The information gathered is not guaranteed to be 100% accurate. 
      */
-    supportedBiometricSensors(): Promise<Success<BiometricSensors> | Failure<SecureCredentialsError>>
+    supportedBiometricSensors(): Promise<Success<BiometricSensors>>
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -37,7 +37,7 @@ export class SecureCredentialsWeb extends WebPlugin implements SecureCredentials
     return setTimeout(() => console.log('WEB -> maximumAllowedSecurityLevel?') , 1000) as unknown as Success<SecurityLevel> | Failure<SecureCredentialsError>;
   }
 
-  async supportedBiometricSensors(): Promise<Success<BiometricSensors> | Failure<SecureCredentialsError>> {
-      return setTimeout(() => console.log('WEB -> supportedBiometricSensors?') , 1000) as unknown as Success<BiometricSensors> | Failure<SecureCredentialsError>;
+  async supportedBiometricSensors(): Promise<Success<BiometricSensors>> {
+      return setTimeout(() => console.log('WEB -> supportedBiometricSensors?') , 1000) as unknown as Success<BiometricSensors>;
   }
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -7,7 +7,8 @@ import {
   SecureCredentialsPlugin,
   SecurityLevel,
   Success,
-  CredentialOptions
+  CredentialOptions,
+  BiometricSensors
 } from './definitions';
 
 export class SecureCredentialsWeb extends WebPlugin implements SecureCredentialsPlugin {
@@ -34,5 +35,9 @@ export class SecureCredentialsWeb extends WebPlugin implements SecureCredentials
 
   async maximumSecurityLevel(): Promise<Success<SecurityLevel> | Failure<SecureCredentialsError>> {
     return setTimeout(() => console.log('WEB -> maximumAllowedSecurityLevel?') , 1000) as unknown as Success<SecurityLevel> | Failure<SecureCredentialsError>;
+  }
+
+  async supportedBiometricSensors(): Promise<Success<BiometricSensors> | Failure<SecureCredentialsError>> {
+      return setTimeout(() => console.log('WEB -> supportedBiometricSensors?') , 1000) as unknown as Success<BiometricSensors> | Failure<SecureCredentialsError>;
   }
 }


### PR DESCRIPTION
The supportedBiometricSensors will allow consumers to determine if they should use terminology in their application such as TouchID or FaceID to improve their user experience. This change will provide information on what sensors are available if the device shares that information out. Some android devices do not share sensor information for security purposes.